### PR TITLE
Patch on routing for email identifiers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Masq::Engine.routes.draw do
   post "/consumer/start" => "consumer#start", :as => :consumer_start
   match "/consumer/complete" => "consumer#complete", :as => :consumer_complete
 
-  get "/*account" => "accounts#show", :as => :identity
+  get "/*account" => "accounts#show", :as => :identity,  :constraints => {:format => /\.xrds/}
 
   root :to => "info#index"
 end


### PR DESCRIPTION
Fix the show account route for email addresses by restricting
the expected formats to only xrds (#3)
