### PR TITLE
Oracle compatibility - renaming column

### DIFF
--- a/app/controllers/masq/server_controller.rb
+++ b/app/controllers/masq/server_controller.rb
@@ -213,7 +213,7 @@ module Masq
     # http://openid.net/specs/openid-provider-authentication-policy-extension-1_0-01.html#anchor12
     def auth_level
       if Masq::Engine.config.masq['use_ssl']
-        current_account.yubikey_last_authenticated_at? ? 3 : 2
+        current_account.last_authenticated_by_yubikey? ? 3 : 2
       else
         0
       end
@@ -224,7 +224,7 @@ module Masq
     end
 
     def auth_policies
-      current_account.yubikey_last_authenticated_at? ?
+      current_account.last_authenticated_by_yubikey? ?
         [OpenID::PAPE::AUTH_MULTI_FACTOR, OpenID::PAPE::AUTH_PHISHING_RESISTANT] :
         []
     end

--- a/app/controllers/masq/server_controller.rb
+++ b/app/controllers/masq/server_controller.rb
@@ -213,7 +213,7 @@ module Masq
     # http://openid.net/specs/openid-provider-authentication-policy-extension-1_0-01.html#anchor12
     def auth_level
       if Masq::Engine.config.masq['use_ssl']
-        current_account.last_authenticated_with_yubikey? ? 3 : 2
+        current_account.yubikey_last_authenticated_at? ? 3 : 2
       else
         0
       end
@@ -224,7 +224,7 @@ module Masq
     end
 
     def auth_policies
-      current_account.last_authenticated_with_yubikey? ?
+      current_account.yubikey_last_authenticated_at? ?
         [OpenID::PAPE::AUTH_MULTI_FACTOR, OpenID::PAPE::AUTH_PHISHING_RESISTANT] :
         []
     end

--- a/app/models/masq/account.rb
+++ b/app/models/masq/account.rb
@@ -95,7 +95,7 @@ module Masq
 
       if not a.nil? and a.active? and a.enabled
         if a.authenticated?(password) or (Masq::Engine.config.masq['trust_basic_auth'] and basic_auth_used)
-          a.last_authenticated_at, a.yubikey_last_authenticated_at = Time.now, a.authenticated_with_yubikey?
+          a.last_authenticated_at, a.last_authenticated_by_yubikey = Time.now, a.authenticated_with_yubikey?
           a.save(:validate => false)
           return a
         end

--- a/app/models/masq/account.rb
+++ b/app/models/masq/account.rb
@@ -95,7 +95,7 @@ module Masq
 
       if not a.nil? and a.active? and a.enabled
         if a.authenticated?(password) or (Masq::Engine.config.masq['trust_basic_auth'] and basic_auth_used)
-          a.last_authenticated_at, a.last_authenticated_with_yubikey = Time.now, a.authenticated_with_yubikey?
+          a.last_authenticated_at, a.yubikey_last_authenticated_at = Time.now, a.authenticated_with_yubikey?
           a.save(:validate => false)
           return a
         end

--- a/db/migrate/20120312120000_masq_schema.rb
+++ b/db/migrate/20120312120000_masq_schema.rb
@@ -22,7 +22,7 @@ class MasqSchema < ActiveRecord::Migration
         t.string   :yubico_identity,     :limit => 12
         t.integer  :public_persona_id
         t.datetime :last_authenticated_at
-        t.boolean  :yubikey_last_authenticated_at
+        t.boolean  :last_authenticated_by_yubikey
         t.boolean  :yubikey_mandatory, :default => false, :null => false
         t.datetime :remember_token_expires_at
         t.datetime :activated_at

--- a/db/migrate/20120312120000_masq_schema.rb
+++ b/db/migrate/20120312120000_masq_schema.rb
@@ -22,7 +22,7 @@ class MasqSchema < ActiveRecord::Migration
         t.string   :yubico_identity,     :limit => 12
         t.integer  :public_persona_id
         t.datetime :last_authenticated_at
-        t.boolean  :last_authenticated_with_yubikey
+        t.boolean  :yubikey_last_authenticated_at
         t.boolean  :yubikey_mandatory, :default => false, :null => false
         t.datetime :remember_token_expires_at
         t.datetime :activated_at

--- a/db/migrate/20130626220915_remame_last_authenticated_with_yubikey_on_masq_accounts.rb
+++ b/db/migrate/20130626220915_remame_last_authenticated_with_yubikey_on_masq_accounts.rb
@@ -2,7 +2,7 @@ class RemameLastAuthenticatedWithYubikeyOnMasqAccounts < ActiveRecord::Migration
   def up
     # Rename the last last_authenticated_with_yubikey to be within the 30 char column name limit set by Oracle.
     if table_exists?(:masq_accounts) && column_exists?(:masq_accounts, :last_authenticated_with_yubikey)
-      rename_column :masq_accounts, :last_authenticated_with_yubikey, :last_authenticated_by_yubi
+      rename_column :masq_accounts, :last_authenticated_with_yubikey, :last_authenticated_by_yubikey
     end
   end
 

--- a/db/migrate/20130626220915_remame_last_authenticated_with_yubikey_on_masq_accounts.rb
+++ b/db/migrate/20130626220915_remame_last_authenticated_with_yubikey_on_masq_accounts.rb
@@ -1,0 +1,11 @@
+class RemameLastAuthenticatedWithYubikeyOnMasqAccounts < ActiveRecord::Migration
+  def up
+    # Rename the last last_authenticated_with_yubikey to be within the 30 char column name limit set by Oracle.
+    if table_exists?(:masq_accounts) && column_exists?(:masq_accounts, :last_authenticated_with_yubikey)
+      rename_column :masq_accounts, :last_authenticated_with_yubikey, :last_authenticated_by_yubi
+    end
+  end
+
+  def down
+  end
+end

--- a/lib/tasks/masq_tasks.rake
+++ b/lib/tasks/masq_tasks.rake
@@ -51,6 +51,7 @@ namespace :masq do
 
     desc "Run CI build task"
     task :ci => [:prepare_ci] do
+      Rake::Task['db:migrate'].invoke
       Rake::Task['test'].invoke
     end
   end

--- a/lib/tasks/masq_tasks.rake
+++ b/lib/tasks/masq_tasks.rake
@@ -51,7 +51,6 @@ namespace :masq do
 
     desc "Run CI build task"
     task :ci => [:prepare_ci] do
-      Rake::Task['db:migrate'].invoke
       Rake::Task['test'].invoke
     end
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120312120000) do
+ActiveRecord::Schema.define(:version => 20130626220915) do
 
   create_table "masq_accounts", :force => true do |t|
     t.boolean  "enabled",                                       :default => true
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(:version => 20120312120000) do
     t.string   "yubico_identity",                 :limit => 12
     t.integer  "public_persona_id"
     t.datetime "last_authenticated_at"
-    t.boolean  "last_authenticated_with_yubikey"
+    t.boolean  "last_authenticated_by_yubikey"
     t.boolean  "yubikey_mandatory",                             :default => false, :null => false
     t.datetime "remember_token_expires_at"
     t.datetime "activated_at"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(:version => 20120312120000) do
     t.string   "yubico_identity",                 :limit => 12
     t.integer  "public_persona_id"
     t.datetime "last_authenticated_at"
-    t.boolean  "last_authenticated_with_yubikey"
+    t.boolean  "yubikey_last_authenticated_at"
     t.boolean  "yubikey_mandatory",                             :default => false, :null => false
     t.datetime "remember_token_expires_at"
     t.datetime "activated_at"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(:version => 20120312120000) do
     t.string   "yubico_identity",                 :limit => 12
     t.integer  "public_persona_id"
     t.datetime "last_authenticated_at"
-    t.boolean  "yubikey_last_authenticated_at"
+    t.boolean  "last_authenticated_by_yubikey"
     t.boolean  "yubikey_mandatory",                             :default => false, :null => false
     t.datetime "remember_token_expires_at"
     t.datetime "activated_at"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(:version => 20120312120000) do
     t.string   "yubico_identity",                 :limit => 12
     t.integer  "public_persona_id"
     t.datetime "last_authenticated_at"
-    t.boolean  "last_authenticated_by_yubikey"
+    t.boolean  "last_authenticated_with_yubikey"
     t.boolean  "yubikey_mandatory",                             :default => false, :null => false
     t.datetime "remember_token_expires_at"
     t.datetime "activated_at"

--- a/test/functional/masq/sessions_controller_test.rb
+++ b/test/functional/masq/sessions_controller_test.rb
@@ -117,7 +117,7 @@ module Masq
       post :create, :login => @account.login, :password => 'test'
       @account.reload
       assert_not_nil @account.last_authenticated_at
-      assert !@account.last_authenticated_with_yubikey
+      assert !@account.yubikey_last_authenticated_at
     end
 
     def test_should_authenticate_with_password_and_yubico_otp
@@ -127,7 +127,7 @@ module Masq
       post :create, :login => @account.login, :password => 'test' + yubico_otp
       @account.reload
       assert_not_nil @account.last_authenticated_at
-      assert @account.last_authenticated_with_yubikey
+      assert @account.yubikey_last_authenticated_at
     end
 
     def test_should_disallow_password_only_login_when_yubikey_is_mandatory

--- a/test/functional/masq/sessions_controller_test.rb
+++ b/test/functional/masq/sessions_controller_test.rb
@@ -117,7 +117,7 @@ module Masq
       post :create, :login => @account.login, :password => 'test'
       @account.reload
       assert_not_nil @account.last_authenticated_at
-      assert !@account.yubikey_last_authenticated_at
+      assert !@account.last_authenticated_by_yubikey
     end
 
     def test_should_authenticate_with_password_and_yubico_otp
@@ -127,7 +127,7 @@ module Masq
       post :create, :login => @account.login, :password => 'test' + yubico_otp
       @account.reload
       assert_not_nil @account.last_authenticated_at
-      assert @account.yubikey_last_authenticated_at
+      assert @account.last_authenticated_by_yubikey
     end
 
     def test_should_disallow_password_only_login_when_yubikey_is_mandatory


### PR DESCRIPTION
Renamed the last_authenticated_with_yubikey table column to be less than
30 characters long so that this gem is compadible with oracle databases

This is a duplicate of #11 since I want to rename my forks branch.
