### PR TITLE
Lower dependency on ruby-openid for ruby >= 2

### DIFF
--- a/masq.gemspec
+++ b/masq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 3.2.16"
-  s.add_dependency "ruby-openid", "~> 2.5.0"
+  s.add_dependency "ruby-openid", "~> 2.5"
   s.add_dependency "ruby-yadis"
   s.add_dependency "yubikey"
   s.add_dependency "i18n_data"


### PR DESCRIPTION
ruby-openid 2.5 uses Digest::HMAC which was experimental. Newer version should use OpenSSL::HMAC.
According to my simple test, using ruby-openid 2.7.0 did the job.
